### PR TITLE
Map exported paths manually for old Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     }
   },
   "exports": {
+    "./promise.js": "dist/promise.js",
+    "./stream.js": "dist/stream.js",
+    "./string.js": "dist/string.js",
     "./*.js": "dist/*.js"
   },
   "scripts": {


### PR DESCRIPTION
To support old Webpack that can't recognize wildcards in `exports` field. https://nodejs.org/api/packages.html#subpath-exports